### PR TITLE
MailChimp API-URL

### DIFF
--- a/pyrate/services/mailchimp.py
+++ b/pyrate/services/mailchimp.py
@@ -24,7 +24,7 @@ class MailchimpPyrate(Pyrate):
 
     def __init__(self, apikey, default_response_format=None):
         super(MailchimpPyrate, self).__init__()
-        self.base_url = 'https://' + apikey[-3:] + '.api.mailchimp.com/2.0/'
+        self.base_url = 'https://' + apikey.split('-)[-1] + '.api.mailchimp.com/2.0/'
         self.default_body_content = {
             'apikey': apikey
         }

--- a/pyrate/services/mailchimp.py
+++ b/pyrate/services/mailchimp.py
@@ -24,7 +24,7 @@ class MailchimpPyrate(Pyrate):
 
     def __init__(self, apikey, default_response_format=None):
         super(MailchimpPyrate, self).__init__()
-        self.base_url = 'https://' + apikey.split('-)[-1] + '.api.mailchimp.com/2.0/'
+        self.base_url = 'https://' + apikey.split('-')[-1] + '.api.mailchimp.com/2.0/'
         self.default_body_content = {
             'apikey': apikey
         }


### PR DESCRIPTION
Fixed (hopefully) API-Key handling for MailChimp.

Implementation did use

```
apikey[-3:]
```

but this only works for one-digit API hostnames. Did get an error with a relatively new key: **"***-us10"**.
This key obviously should use **us10.api.mailchimp.com** - but resulted in **s10.api.mailchimp.com**
